### PR TITLE
Ruby 1.9で'テスト'などカタカナを含んだ文字を解析するとと起こっていたエラーを修正

### DIFF
--- a/lib/igo/dictionary.rb
+++ b/lib/igo/dictionary.rb
@@ -104,6 +104,7 @@ module Igo
     #wdic::
     #result::
     def search(text, start, wdic, result)
+      text = text.force_encoding('binary') if text.respond_to?(:force_encoding)
       txt = text.unpack("U*")
       length = txt.size
       ch = txt[start]
@@ -118,8 +119,9 @@ module Igo
     
       for i in start..(limit - 1)
         wdic.search_from_trie_id(ct.id, start, (i - start) + 1, is_space, result)
-      
-        if((i + 1) != limit and !(@category.compatible?(ch, text[i + 1])))
+        
+        ch2 = text[i + 1].is_a?(String) ? text[i + 1].ord : text[i + 1]
+        if((i + 1) != limit and !(@category.compatible?(ch, ch2)))
           return
         end
       end

--- a/lib/igo/dictionary.rb
+++ b/lib/igo/dictionary.rb
@@ -104,11 +104,16 @@ module Igo
     #wdic::
     #result::
     def search(text, start, wdic, result)
-      text = text.force_encoding('binary') if text.respond_to?(:force_encoding)
       txt = text.unpack("U*")
       length = txt.size
       ch = txt[start]
       ct = @category.category(ch)
+
+      if RUBY_VERSION >= '1.9.0'
+        txt2 = text.bytes.to_a
+      else
+        txt2 = text.unpack('C*')
+      end
     
       if !result.empty? and !ct.invoke
         return
@@ -120,8 +125,7 @@ module Igo
       for i in start..(limit - 1)
         wdic.search_from_trie_id(ct.id, start, (i - start) + 1, is_space, result)
         
-        ch2 = text[i + 1].is_a?(String) ? text[i + 1].ord : text[i + 1]
-        if((i + 1) != limit and !(@category.compatible?(ch, ch2)))
+        if((i + 1) != limit and !(@category.compatible?(ch, txt2[i + 1])))
           return
         end
       end


### PR DESCRIPTION
有用なライブラリの公開をありがとうございます！

Ruby 1.9でカタカナを解析出来ない現象が起こったので、小手先ですが修正しました。
確認用のコードは下記の様になります。
https://gist.github.com/952087

非常にかっこわるいパッチですが、受け取って頂けるか、できればもっとかっこよく書き直して貰えるとうれしいです。

p.s
同様のエラーが下記のブログでも、報告されていました。
http://g86.dbcls.jp/~yag/wordpress/archives/1372

よろしくお願いします。
