### PR TITLE
igo-ruby-0.1.4で全角記号混じり文でエラーが出る部分の修正

### DIFF
--- a/lib/igo/dictionary.rb
+++ b/lib/igo/dictionary.rb
@@ -109,9 +109,9 @@ module Igo
       else
         txt = text.unpack('C*')
       end
-      
-      length = txt.size
-      ch = txt[start]
+      txtu = text.unpack("U*")
+      length = txtu.size
+      ch = txtu[start]
       ct = @category.category(ch)
     
       if !result.empty? and !ct.invoke
@@ -131,7 +131,7 @@ module Igo
     
       if ct.group and limit < length
         for i in limit..(length - 1)
-          if not @category.compatible?(ch, txt[i])
+          if not @category.compatible?(ch, txtu[i])
             wdic.search_from_trie_id(ct.id, start, i - start, is_space, result)
             return
           end

--- a/test/test.rb
+++ b/test/test.rb
@@ -20,3 +20,9 @@ puts "1.9 character code bug fix ->"
 t.each{|m|
   puts "#{m.surface} #{m.feature} #{m.start}"
 }
+
+t = tagger.parse('Let’s Dance')
+puts "Fix error raised when fullwidth symbol mixed ->"
+t.each{|m|
+  puts "#{m.surface} #{m.feature} #{m.start}"
+}


### PR DESCRIPTION
igo-ruby-0.1.4では、tagger.parse("Let’s")など、ASCII文字と全角記号が交じると失敗します。

パッチは、最終commitでの修正部分を手前（masudriveさんのtxtとtxt2は両方使い分けているほう）に戻し、問題のケースをtest/test.rbに追加したものです。
